### PR TITLE
Make clients table responsive and accessible

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,8 +185,13 @@
     .table-header h2{margin:0;font-size:22px;font-weight:700;color:var(--ink);text-shadow:0 10px 20px rgba(0,0,0,.35)}
     .table-header p{margin:0;color:var(--muted);font-size:14px}
     .table-card{position:relative;background:rgba(255,255,255,.05);border-radius:20px;border:1px solid var(--border);box-shadow:var(--shadow);overflow:visible;backdrop-filter:blur(18px)}
-    table{width:100%;border-collapse:separate;border-spacing:0;border-radius:inherit}
-    th,td{padding:14px 16px;border-bottom:1px solid rgba(255,255,255,.08);font-size:14px}
+    .table-scroll{position:relative;width:100%;overflow-x:auto;overscroll-behavior-x:contain;-webkit-overflow-scrolling:touch;scrollbar-width:thin;scrollbar-color:rgba(125,211,252,.6) transparent;scrollbar-gutter:stable both-edges}
+    .table-scroll:focus-visible{outline:2px solid rgba(125,211,252,.45);outline-offset:4px}
+    .table-scroll::-webkit-scrollbar{height:10px}
+    .table-scroll::-webkit-scrollbar-track{background:transparent}
+    .table-scroll::-webkit-scrollbar-thumb{background:rgba(125,211,252,.65);border-radius:999px;border:3px solid rgba(0,0,0,0)}
+    table{width:100%;min-width:100%;border-collapse:separate;border-spacing:0;border-radius:inherit}
+    th,td{padding:14px 16px;border-bottom:1px solid rgba(255,255,255,.08);font-size:14px;word-break:break-word;overflow-wrap:anywhere}
     th{text-align:left;color:var(--muted);font-weight:700;letter-spacing:.08em;font-size:12px;text-transform:uppercase}
     td{color:var(--ink);font-weight:500}
     tbody tr{transition:background-color .2s ease,box-shadow .2s ease}
@@ -197,6 +202,32 @@
     tbody tr:last-child td:first-child{border-bottom-left-radius:20px}
     tbody tr:last-child td:last-child{border-bottom-right-radius:20px}
     .table-card th,.table-card td{background-clip:padding-box}
+    .cell-actions{text-align:right}
+    @media(max-width:639px){
+      .table-card{padding:12px}
+      .table-scroll{scrollbar-width:auto}
+      #tabla{display:block}
+      #tabla thead{display:none}
+      #tabla tbody{display:grid;gap:16px;padding:4px 0}
+      #tabla tbody tr{display:grid;grid-template-columns:1fr;gap:12px;padding:18px;border-radius:18px;border:1px solid var(--table-border);background:var(--table-card-bg);box-shadow:0 18px 32px rgba(5,9,15,.35)}
+      #tabla tbody tr:nth-child(even){background:var(--table-card-bg)}
+      #tabla tbody tr:hover{background:var(--table-row-hover-bg);box-shadow:0 22px 38px rgba(5,9,15,.45)}
+      #tabla tbody tr td{display:grid;gap:6px;padding:0;border:0;background:transparent;text-align:left}
+      #tabla tbody tr td::before{content:attr(data-label);font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+      #tabla tbody tr td[data-label=""]::before{content:'';display:none}
+      #tabla tbody tr td .tag{justify-self:start}
+      .cell-actions{justify-items:end}
+      .cell-actions .menu-wrap{justify-self:end}
+    }
+    @media(min-width:640px){
+      #tabla{display:table}
+      .table-scroll thead th{position:sticky;top:0;background:var(--table-card-bg);z-index:2;box-shadow:0 1px 0 var(--table-border)}
+      #tabla thead{display:table-header-group}
+      #tabla tbody{display:table-row-group}
+      #tabla tbody tr{display:table-row}
+      #tabla tbody tr td{display:table-cell;padding:14px 16px}
+      #tabla tbody tr td::before{display:none}
+    }
     .tag{font-size:12px;padding:4px 10px;border-radius:999px;display:inline-block;border:1px solid rgba(255,255,255,.2);background:rgba(255,255,255,.05);color:var(--ink);backdrop-filter:blur(12px)}
     .tag.ok{color:var(--ok);background:rgba(74,222,128,.16);border-color:rgba(74,222,128,.38)}
     .tag.warn{color:var(--warn);background:rgba(251,191,36,.16);border-color:rgba(251,191,36,.38)}
@@ -397,19 +428,21 @@
     <!-- tabla -->
     <section class="table-section">
       <div class="table-header">
-        <h2>Clientes registrados</h2>
+        <h2 id="clientesTitulo">Clientes registrados</h2>
         <p>Consulta el listado completo y gestiona cada registro.</p>
       </div>
       <div class="table-card">
-        <table id="tabla">
-          <thead>
-            <tr>
-              <th>Nombre</th><th>Email</th><th>Servicio</th>
-              <th>Inicio</th><th>Vence</th><th>Estado</th><th>Días</th><th></th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
+        <div class="table-scroll" role="region" aria-labelledby="clientesTitulo" tabindex="0">
+          <table id="tabla">
+            <thead>
+              <tr>
+                <th>Nombre</th><th>Email</th><th>Servicio</th>
+                <th>Inicio</th><th>Vence</th><th>Estado</th><th>Días</th><th><span class="sr-only">Acciones</span></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
       </div>
     </section>
   </div>
@@ -950,14 +983,14 @@ async function renderTabla(){
     const estTxt=est?est[0].toUpperCase()+est.slice(1):'-';
     const diasTxt= d==null?'-':(d<0?`Vencido ${Math.abs(d)} d`:`Faltan ${d} d`);
     return `<tr>
-      <td>${esc(x.nombre)}</td>
-      <td>${esc(x.email||'')}</td>
-      <td>${esc(x.servicio||'')}</td>
-      <td>${fmt(x.inicio)}</td>
-      <td>${fmt(x.vence)}</td>
-      <td>${est?`<span class="tag ${tag}">${estTxt}</span>`:'-'}</td>
-      <td>${diasTxt}</td>
-      <td style="text-align:right">
+      <td data-label="Nombre">${esc(x.nombre)}</td>
+      <td data-label="Email">${esc(x.email||'')}</td>
+      <td data-label="Servicio">${esc(x.servicio||'')}</td>
+      <td data-label="Inicio">${fmt(x.inicio)}</td>
+      <td data-label="Vence">${fmt(x.vence)}</td>
+      <td data-label="Estado">${est?`<span class="tag ${tag}">${estTxt}</span>`:'-'}</td>
+      <td data-label="Días">${diasTxt}</td>
+      <td data-label="Acciones" class="cell-actions">
         <div class="menu-wrap">
           <button class="kebab" data-menu-toggle aria-haspopup="menu" aria-expanded="false"><span class="dots">⋯</span></button>
           <div class="menu" role="menu">


### PR DESCRIPTION
## Summary
- wrap the clients table in an accessible scroll container and keep headers sticky on viewports ≥640px
- add a mobile card layout that uses CSS grid and data-label pseudo content to prevent horizontal scrolling on small screens
- tag rendered table cells with their labels so responsive styles remain readable across breakpoints

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d05d62a7e0832e86c3123a446ce373