### PR TITLE
Refresh button styling with gradients and layered shadows

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,81 @@
       --addserv-hover-border:rgba(242,138,45,.4);
       --addserv-active-bg:rgba(242,138,45,.24);
       --addserv-active-border:rgba(242,138,45,.5);
+      --btn-base-bg-top:rgba(255,255,255,.16);
+      --btn-base-bg-bottom:rgba(15,23,42,.28);
+      --btn-base-hover-top:rgba(255,255,255,.22);
+      --btn-base-hover-bottom:rgba(15,23,42,.36);
+      --btn-base-active-top:rgba(255,255,255,.12);
+      --btn-base-active-bottom:rgba(15,23,42,.22);
+      --btn-base-shadow-soft:rgba(3,6,10,.55);
+      --btn-base-shadow-strong:rgba(3,6,10,.32);
+      --btn-base-shadow-hover-soft:rgba(3,6,10,.6);
+      --btn-base-shadow-hover-strong:rgba(3,6,10,.4);
+      --btn-base-shadow-active-soft:rgba(3,6,10,.45);
+      --btn-base-shadow-active-strong:rgba(3,6,10,.5);
+      --btn-base-highlight:rgba(255,255,255,.24);
+      --btn-base-highlight-hover:rgba(255,255,255,.3);
+      --btn-base-highlight-active:rgba(255,255,255,.2);
+      --btn-ghost-bg-top:rgba(255,255,255,.18);
+      --btn-ghost-bg-bottom:rgba(32,43,62,.24);
+      --btn-ghost-hover-top:rgba(255,255,255,.24);
+      --btn-ghost-hover-bottom:rgba(32,43,62,.3);
+      --btn-ghost-active-top:rgba(255,255,255,.16);
+      --btn-ghost-active-bottom:rgba(32,43,62,.24);
+      --btn-ghost-shadow-soft:rgba(8,12,20,.45);
+      --btn-ghost-shadow-strong:rgba(3,6,12,.32);
+      --btn-ghost-shadow-hover-soft:rgba(8,12,20,.55);
+      --btn-ghost-shadow-hover-strong:rgba(3,6,12,.42);
+      --btn-ghost-shadow-active-soft:rgba(6,10,18,.4);
+      --btn-ghost-shadow-active-strong:rgba(3,6,12,.5);
+      --btn-ghost-highlight:rgba(255,255,255,.28);
+      --btn-ghost-highlight-hover:rgba(255,255,255,.32);
+      --btn-ghost-highlight-active:rgba(255,255,255,.24);
+      --btn-primary-bg-top:#ffb15f;
+      --btn-primary-bg-bottom:#d56715;
+      --btn-primary-hover-top:#ffc070;
+      --btn-primary-hover-bottom:#cf661d;
+      --btn-primary-active-top:#f49a3c;
+      --btn-primary-active-bottom:#d2641d;
+      --btn-primary-shadow-soft:rgba(242,138,45,.5);
+      --btn-primary-shadow-strong:rgba(199,98,18,.42);
+      --btn-primary-shadow-hover-soft:rgba(242,138,45,.55);
+      --btn-primary-shadow-hover-strong:rgba(199,98,18,.5);
+      --btn-primary-shadow-active-soft:rgba(173,83,20,.48);
+      --btn-primary-shadow-active-strong:rgba(130,60,14,.58);
+      --btn-primary-highlight:rgba(255,237,213,.7);
+      --btn-primary-highlight-hover:rgba(255,244,227,.78);
+      --btn-primary-highlight-active:rgba(255,230,202,.62);
+      --addserv-bg-top:rgba(255,255,255,.14);
+      --addserv-bg-bottom:rgba(242,138,45,.18);
+      --addserv-hover-top:rgba(242,138,45,.3);
+      --addserv-hover-bottom:rgba(176,90,24,.26);
+      --addserv-active-top:rgba(242,138,45,.24);
+      --addserv-active-bottom:rgba(160,78,22,.28);
+      --addserv-shadow-soft:rgba(5,9,15,.42);
+      --addserv-shadow-strong:rgba(5,9,15,.28);
+      --addserv-shadow-hover-soft:rgba(5,9,15,.52);
+      --addserv-shadow-hover-strong:rgba(5,9,15,.36);
+      --addserv-shadow-active-soft:rgba(5,9,15,.45);
+      --addserv-shadow-active-strong:rgba(5,9,15,.5);
+      --addserv-highlight:rgba(255,255,255,.24);
+      --addserv-highlight-hover:rgba(255,255,255,.28);
+      --addserv-highlight-active:rgba(255,255,255,.2);
+      --launcher-bg-top:rgba(255,255,255,.32);
+      --launcher-bg-bottom:rgba(12,20,32,.68);
+      --launcher-hover-top:rgba(255,255,255,.38);
+      --launcher-hover-bottom:rgba(16,26,42,.74);
+      --launcher-active-top:rgba(236,242,255,.26);
+      --launcher-active-bottom:rgba(10,16,28,.58);
+      --launcher-shadow-soft:rgba(3,6,10,.55);
+      --launcher-shadow-strong:rgba(3,6,10,.35);
+      --launcher-shadow-hover-soft:rgba(3,6,10,.6);
+      --launcher-shadow-hover-strong:rgba(3,6,10,.42);
+      --launcher-shadow-active-soft:rgba(2,4,8,.5);
+      --launcher-shadow-active-strong:rgba(2,4,8,.42);
+      --launcher-highlight:rgba(255,255,255,.42);
+      --launcher-highlight-hover:rgba(255,255,255,.48);
+      --launcher-highlight-active:rgba(255,255,255,.34);
       --tag-border:rgba(255,255,255,.2);
       --tag-bg:rgba(255,255,255,.05);
     }
@@ -98,6 +173,75 @@
       --addserv-active-border:rgba(37,99,235,.6);
       --tag-border:rgba(148,163,184,.6);
       --tag-bg:#e2e8f0;
+      --btn-base-bg-top:#ffffff;
+      --btn-base-bg-bottom:#dce6f6;
+      --btn-base-hover-top:#f8fbff;
+      --btn-base-hover-bottom:#cbdaf3;
+      --btn-base-active-top:#eef3fb;
+      --btn-base-active-bottom:#c2d1ee;
+      --btn-base-shadow-soft:rgba(15,23,42,.16);
+      --btn-base-shadow-strong:rgba(15,23,42,.1);
+      --btn-base-shadow-hover-soft:rgba(15,23,42,.22);
+      --btn-base-shadow-hover-strong:rgba(15,23,42,.14);
+      --btn-base-shadow-active-soft:rgba(15,23,42,.16);
+      --btn-base-shadow-active-strong:rgba(15,23,42,.2);
+      --btn-base-highlight:rgba(255,255,255,.9);
+      --btn-base-highlight-hover:rgba(255,255,255,.95);
+      --btn-base-highlight-active:rgba(255,255,255,.82);
+      --btn-ghost-bg-top:#f8fafc;
+      --btn-ghost-bg-bottom:#dce5f3;
+      --btn-ghost-hover-top:#eef4ff;
+      --btn-ghost-hover-bottom:#cbd9f2;
+      --btn-ghost-active-top:#e2e9f6;
+      --btn-ghost-active-bottom:#c3d3eb;
+      --btn-ghost-shadow-soft:rgba(15,23,42,.12);
+      --btn-ghost-shadow-strong:rgba(15,23,42,.08);
+      --btn-ghost-shadow-hover-soft:rgba(15,23,42,.18);
+      --btn-ghost-shadow-hover-strong:rgba(15,23,42,.12);
+      --btn-ghost-shadow-active-soft:rgba(15,23,42,.12);
+      --btn-ghost-shadow-active-strong:rgba(15,23,42,.18);
+      --btn-ghost-highlight:rgba(255,255,255,.85);
+      --btn-ghost-highlight-hover:rgba(255,255,255,.9);
+      --btn-ghost-highlight-active:rgba(255,255,255,.8);
+      --btn-primary-shadow-soft:rgba(242,138,45,.36);
+      --btn-primary-shadow-strong:rgba(199,98,18,.28);
+      --btn-primary-shadow-hover-soft:rgba(242,138,45,.42);
+      --btn-primary-shadow-hover-strong:rgba(199,98,18,.36);
+      --btn-primary-shadow-active-soft:rgba(173,83,20,.32);
+      --btn-primary-shadow-active-strong:rgba(130,60,14,.45);
+      --btn-primary-highlight:rgba(255,244,227,.85);
+      --btn-primary-highlight-hover:rgba(255,248,235,.9);
+      --btn-primary-highlight-active:rgba(255,236,210,.78);
+      --addserv-bg-top:#fdf4e0;
+      --addserv-bg-bottom:#fbe1bf;
+      --addserv-hover-top:#fbe1bf;
+      --addserv-hover-bottom:#f0b978;
+      --addserv-active-top:#f7c68f;
+      --addserv-active-bottom:#e89b54;
+      --addserv-shadow-soft:rgba(148,163,184,.32);
+      --addserv-shadow-strong:rgba(148,163,184,.18);
+      --addserv-shadow-hover-soft:rgba(148,163,184,.4);
+      --addserv-shadow-hover-strong:rgba(148,163,184,.24);
+      --addserv-shadow-active-soft:rgba(148,163,184,.32);
+      --addserv-shadow-active-strong:rgba(148,163,184,.28);
+      --addserv-highlight:rgba(255,255,255,.9);
+      --addserv-highlight-hover:rgba(255,255,255,.95);
+      --addserv-highlight-active:rgba(255,255,255,.88);
+      --launcher-bg-top:#ffffff;
+      --launcher-bg-bottom:#dbe6fb;
+      --launcher-hover-top:#f8fbff;
+      --launcher-hover-bottom:#c6d8f9;
+      --launcher-active-top:#eef4ff;
+      --launcher-active-bottom:#bed0f3;
+      --launcher-shadow-soft:rgba(15,23,42,.16);
+      --launcher-shadow-strong:rgba(15,23,42,.12);
+      --launcher-shadow-hover-soft:rgba(15,23,42,.22);
+      --launcher-shadow-hover-strong:rgba(15,23,42,.16);
+      --launcher-shadow-active-soft:rgba(15,23,42,.18);
+      --launcher-shadow-active-strong:rgba(15,23,42,.14);
+      --launcher-highlight:rgba(255,255,255,.9);
+      --launcher-highlight-hover:rgba(255,255,255,.95);
+      --launcher-highlight-active:rgba(255,255,255,.85);
     }
     body.theme-light::before{
       background:radial-gradient(circle at 20% 20%,rgba(59,130,246,.15),rgba(148,163,184,0) 45%),
@@ -110,27 +254,108 @@
 
     body.sidebar-expanded{padding-left:260px}
     /* ===== Sidebar y lanzador flotante ===== */
-    .sidebar-launcher{position:fixed;top:20px;left:20px;width:54px;height:54px;border-radius:999px;border:1px solid rgba(255,255,255,.18);background:var(--card-bg);color:var(--ink);display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer;z-index:60;box-shadow:0 18px 36px rgba(0,0,0,.45);backdrop-filter:blur(18px);transition:left .3s ease,transform .2s ease,box-shadow .2s ease,background-color .2s ease,border-color .2s ease}
-    .sidebar-launcher:hover,.sidebar-launcher:focus-visible{transform:translateY(-1px);box-shadow:0 24px 40px rgba(0,0,0,.5);background:rgba(255,255,255,.08);border-color:rgba(255,255,255,.26)}
-    .sidebar-launcher:active{transform:translateY(0);box-shadow:0 14px 28px rgba(0,0,0,.55)}
+    .sidebar-launcher{position:fixed;top:20px;left:20px;width:54px;height:54px;border-radius:999px;border:1px solid rgba(255,255,255,.18);
+      background:linear-gradient(145deg,var(--launcher-bg-top),var(--launcher-bg-bottom));color:var(--ink);display:flex;align-items:center;justify-content:center;font-size:24px;cursor:pointer;z-index:60;
+      box-shadow:0 20px 44px var(--launcher-shadow-soft),0 12px 22px var(--launcher-shadow-strong),inset 0 1px 0 var(--launcher-highlight);
+      backdrop-filter:blur(18px);transition:left .3s ease,transform .2s ease,box-shadow .2s ease,background .2s ease,border-color .2s ease;
+    }
+    .sidebar-launcher:hover,.sidebar-launcher:focus-visible{transform:translateY(-1px);
+      background:linear-gradient(145deg,var(--launcher-hover-top),var(--launcher-hover-bottom));
+      box-shadow:0 24px 50px var(--launcher-shadow-hover-soft),0 14px 24px var(--launcher-shadow-hover-strong),inset 0 1px 0 var(--launcher-highlight-hover);
+      border-color:rgba(255,255,255,.26);
+    }
+    .sidebar-launcher:active{transform:translateY(0);
+      background:linear-gradient(145deg,var(--launcher-active-top),var(--launcher-active-bottom));
+      box-shadow:0 16px 30px var(--launcher-shadow-active-soft),0 8px 16px var(--launcher-shadow-active-strong),inset 0 1px 0 var(--launcher-highlight-active);
+    }
     .sidebar-launcher:focus-visible{outline:2px solid rgba(125,211,252,.35);outline-offset:3px}
-    .sidebar-launcher.is-open{background:var(--btn);color:var(--btn-ink);border-color:rgba(255,255,255,.2);box-shadow:0 24px 44px rgba(0,0,0,.5)}
-    .sidebar-launcher.is-open:hover,.sidebar-launcher.is-open:focus-visible{background:#ffa24d}
+    .sidebar-launcher.is-open{background:linear-gradient(145deg,var(--btn-primary-bg-top),var(--btn-primary-bg-bottom));color:var(--btn-ink);border-color:rgba(255,255,255,.24);
+      box-shadow:0 24px 48px var(--btn-primary-shadow-soft),0 12px 24px var(--btn-primary-shadow-strong),inset 0 1px 0 var(--btn-primary-highlight);
+    }
+    .sidebar-launcher.is-open:hover,.sidebar-launcher.is-open:focus-visible{background:linear-gradient(145deg,var(--btn-primary-hover-top),var(--btn-primary-hover-bottom));
+      box-shadow:0 28px 54px var(--btn-primary-shadow-hover-soft),0 14px 28px var(--btn-primary-shadow-hover-strong),inset 0 1px 0 var(--btn-primary-highlight-hover);
+    }
+    .sidebar-launcher.is-open:active{background:linear-gradient(145deg,var(--btn-primary-active-top),var(--btn-primary-active-bottom));
+      box-shadow:0 18px 34px var(--btn-primary-shadow-active-soft),0 10px 20px var(--btn-primary-shadow-active-strong),inset 0 1px 0 var(--btn-primary-highlight-active);
+    }
     body.sidebar-expanded .sidebar-launcher{left:220px}
     .sidebar{position:fixed;inset:0 auto 0 0;width:260px;background:var(--card-bg);border-right:1px solid var(--border);box-shadow:20px 0 40px rgba(0,0,0,.35);padding:60px 20px 20px;display:flex;flex-direction:column;z-index:30;transition:transform .3s ease,box-shadow .3s ease;overflow:hidden;transform:translateX(-100%)}
     .sidebar.pinned,.sidebar.peek{transform:translateX(0)}
     .sidebar.pinned,.sidebar.peek{box-shadow:24px 0 44px rgba(0,0,0,.4)}
     .sidebar .sidebar-content{position:relative;height:100%;overflow-y:auto;padding-right:6px}
     .sidebar .label{transition:opacity .2s ease}
-    .btn{border:0;border-radius:14px;padding:10px 16px;cursor:pointer;font-weight:600;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;color:var(--ink)}
-    .btn.ghost{background:var(--ghost);border:1px solid var(--ghost-border);box-shadow:inset 0 1px 0 rgba(255,255,255,.05)}
-    .btn.primary{background:var(--btn);color:var(--btn-ink);box-shadow:0 12px 24px rgba(242,138,45,.35)}
-    .btn:hover,.btn:focus-visible{box-shadow:0 14px 28px rgba(5,9,15,.45);transform:translateY(-1px)}
-    .btn:active{transform:translateY(0);box-shadow:0 6px 12px rgba(5,9,15,.6)}
-    .btn.ghost:hover,.btn.ghost:focus-visible{background:rgba(255,255,255,.12);border-color:rgba(255,255,255,.26)}
-    .btn.ghost:active{background:rgba(255,255,255,.18);border-color:rgba(255,255,255,.32)}
-    .btn.primary:hover,.btn.primary:focus-visible{background:#ffa24d}
-    .btn.primary:active{background:#f28a2d}
+    .btn{border:0;border-radius:14px;padding:10px 16px;cursor:pointer;font-weight:600;color:var(--ink);
+      transition:background .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;
+      --btn-bg-top:var(--btn-base-bg-top);
+      --btn-bg-bottom:var(--btn-base-bg-bottom);
+      --btn-hover-bg-top:var(--btn-base-hover-top);
+      --btn-hover-bg-bottom:var(--btn-base-hover-bottom);
+      --btn-active-bg-top:var(--btn-base-active-top);
+      --btn-active-bg-bottom:var(--btn-base-active-bottom);
+      --btn-shadow-soft:var(--btn-base-shadow-soft);
+      --btn-shadow-strong:var(--btn-base-shadow-strong);
+      --btn-shadow-hover-soft:var(--btn-base-shadow-hover-soft);
+      --btn-shadow-hover-strong:var(--btn-base-shadow-hover-strong);
+      --btn-shadow-active-soft:var(--btn-base-shadow-active-soft);
+      --btn-shadow-active-strong:var(--btn-base-shadow-active-strong);
+      --btn-highlight:var(--btn-base-highlight);
+      --btn-highlight-hover:var(--btn-base-highlight-hover);
+      --btn-highlight-active:var(--btn-base-highlight-active);
+      background:linear-gradient(145deg,var(--btn-bg-top),var(--btn-bg-bottom));
+      box-shadow:0 18px 32px var(--btn-shadow-soft),0 8px 16px var(--btn-shadow-strong),inset 0 1px 0 var(--btn-highlight);
+    }
+    .btn:hover,.btn:focus-visible{background:linear-gradient(145deg,var(--btn-hover-bg-top),var(--btn-hover-bg-bottom));
+      box-shadow:0 22px 36px var(--btn-shadow-hover-soft),0 12px 20px var(--btn-shadow-hover-strong),inset 0 1px 0 var(--btn-highlight-hover);
+      transform:translateY(-1px);
+    }
+    .btn:active{transform:translateY(0);
+      background:linear-gradient(145deg,var(--btn-active-bg-top),var(--btn-active-bg-bottom));
+      box-shadow:0 12px 22px var(--btn-shadow-active-soft),0 6px 12px var(--btn-shadow-active-strong),inset 0 1px 0 var(--btn-highlight-active);
+    }
+    .btn.ghost{border:1px solid var(--ghost-border);
+      --btn-bg-top:var(--btn-ghost-bg-top);
+      --btn-bg-bottom:var(--btn-ghost-bg-bottom);
+      --btn-hover-bg-top:var(--btn-ghost-hover-top);
+      --btn-hover-bg-bottom:var(--btn-ghost-hover-bottom);
+      --btn-active-bg-top:var(--btn-ghost-active-top);
+      --btn-active-bg-bottom:var(--btn-ghost-active-bottom);
+      --btn-shadow-soft:var(--btn-ghost-shadow-soft);
+      --btn-shadow-strong:var(--btn-ghost-shadow-strong);
+      --btn-shadow-hover-soft:var(--btn-ghost-shadow-hover-soft);
+      --btn-shadow-hover-strong:var(--btn-ghost-shadow-hover-strong);
+      --btn-shadow-active-soft:var(--btn-ghost-shadow-active-soft);
+      --btn-shadow-active-strong:var(--btn-ghost-shadow-active-strong);
+      --btn-highlight:var(--btn-ghost-highlight);
+      --btn-highlight-hover:var(--btn-ghost-highlight-hover);
+      --btn-highlight-active:var(--btn-ghost-highlight-active);
+      background:linear-gradient(145deg,var(--btn-bg-top),var(--btn-bg-bottom));
+    }
+    .btn.ghost:hover,.btn.ghost:focus-visible{border-color:var(--ghost-hover-border);
+      background:linear-gradient(145deg,var(--btn-hover-bg-top),var(--btn-hover-bg-bottom));
+    }
+    .btn.ghost:active{border-color:var(--ghost-active-border);
+      background:linear-gradient(145deg,var(--btn-active-bg-top),var(--btn-active-bg-bottom));
+    }
+    .btn.primary{color:var(--btn-ink);
+      --btn-bg-top:var(--btn-primary-bg-top);
+      --btn-bg-bottom:var(--btn-primary-bg-bottom);
+      --btn-hover-bg-top:var(--btn-primary-hover-top);
+      --btn-hover-bg-bottom:var(--btn-primary-hover-bottom);
+      --btn-active-bg-top:var(--btn-primary-active-top);
+      --btn-active-bg-bottom:var(--btn-primary-active-bottom);
+      --btn-shadow-soft:var(--btn-primary-shadow-soft);
+      --btn-shadow-strong:var(--btn-primary-shadow-strong);
+      --btn-shadow-hover-soft:var(--btn-primary-shadow-hover-soft);
+      --btn-shadow-hover-strong:var(--btn-primary-shadow-hover-strong);
+      --btn-shadow-active-soft:var(--btn-primary-shadow-active-soft);
+      --btn-shadow-active-strong:var(--btn-primary-shadow-active-strong);
+      --btn-highlight:var(--btn-primary-highlight);
+      --btn-highlight-hover:var(--btn-primary-highlight-hover);
+      --btn-highlight-active:var(--btn-primary-highlight-active);
+      background:linear-gradient(145deg,var(--btn-bg-top),var(--btn-bg-bottom));
+    }
+    .btn.primary:hover,.btn.primary:focus-visible{background:linear-gradient(145deg,var(--btn-hover-bg-top),var(--btn-hover-bg-bottom))}
+    .btn.primary:active{background:linear-gradient(145deg,var(--btn-active-bg-top),var(--btn-active-bg-bottom))}
     .btn:focus-visible{outline:2px solid rgba(125,211,252,.45);outline-offset:3px}
     .linklike{background:none;border:0;color:var(--link);cursor:pointer;padding:0;font-weight:600;position:relative;transition:color .2s ease}
     .linklike::after{content:"";position:absolute;left:0;bottom:-2px;width:100%;height:2px;background:currentColor;transform:scaleX(0);transform-origin:left;transition:transform .2s ease}
@@ -161,9 +386,18 @@
     /* ===== Servicio centrado ===== */
     .center{display:flex;justify-content:center;align-items:center;gap:10px;margin:8px 0 20px}
     .center .label{color:var(--ink-soft)}
-    .addserv{border:1px dashed rgba(255,255,255,.26);background:rgba(255,255,255,.04);color:var(--ink);padding:8px 12px;border-radius:12px;font-size:15px;min-width:40px;text-align:center;transition:background-color .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease}
-    .addserv:hover,.addserv:focus-visible{background:rgba(242,138,45,.16);border-color:rgba(242,138,45,.4);box-shadow:0 10px 24px rgba(5,9,15,.4);transform:translateY(-1px)}
-    .addserv:active{background:rgba(242,138,45,.24);border-color:rgba(242,138,45,.5);transform:translateY(0);box-shadow:0 6px 16px rgba(5,9,15,.6)}
+    .addserv{border:1px dashed var(--addserv-border);background:linear-gradient(145deg,var(--addserv-bg-top),var(--addserv-bg-bottom));color:var(--ink);padding:8px 12px;border-radius:12px;font-size:15px;min-width:40px;text-align:center;
+      transition:background .2s ease,border-color .2s ease,box-shadow .2s ease,transform .2s ease,color .2s ease;
+      box-shadow:0 14px 28px var(--addserv-shadow-soft),0 6px 12px var(--addserv-shadow-strong),inset 0 1px 0 var(--addserv-highlight);
+    }
+    .addserv:hover,.addserv:focus-visible{background:linear-gradient(145deg,var(--addserv-hover-top),var(--addserv-hover-bottom));border-color:var(--addserv-hover-border);
+      box-shadow:0 18px 34px var(--addserv-shadow-hover-soft),0 10px 18px var(--addserv-shadow-hover-strong),inset 0 1px 0 var(--addserv-highlight-hover);
+      transform:translateY(-1px);
+    }
+    .addserv:active{background:linear-gradient(145deg,var(--addserv-active-top),var(--addserv-active-bottom));border-color:var(--addserv-active-border);
+      transform:translateY(0);
+      box-shadow:0 10px 20px var(--addserv-shadow-active-soft),0 4px 10px var(--addserv-shadow-active-strong),inset 0 1px 0 var(--addserv-highlight-active);
+    }
     .addserv:focus-visible{outline:2px solid rgba(242,138,45,.35);outline-offset:2px}
     .addserv.remove{border-color:rgba(251,113,133,.45);color:#fecdd3;background:rgba(248,113,113,.16)}
 


### PR DESCRIPTION
## Summary
- add gradient and shadow tokens for buttons, launcher, and add-service actions in both themes
- restyle `.btn`, `.btn.primary`, `.btn.ghost`, and the sidebar launcher with layered gradients and depth-preserving hover/active states
- refresh the add-service control with warm gradients and multi-layer shadows for a consistent 3D feel

## Testing
- not run (static HTML/CSS only)


------
https://chatgpt.com/codex/tasks/task_e_68d0d2d56bf4832ea5297f6115ed3074