### PR TITLE
Aplicar relieve consistente a campos y toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,12 @@
       --input-border:rgba(255,255,255,.14);
       --input-focus-border:rgba(125,211,252,.6);
       --input-focus-shadow:rgba(125,211,252,.2);
+      --input-bg-top:rgba(255,255,255,.08);
+      --input-bg-bottom:rgba(15,23,42,.28);
+      --input-highlight:rgba(255,255,255,.18);
+      --input-lowlight:rgba(2,6,14,.5);
+      --input-shadow-raised:rgba(3,6,12,.24);
+      --input-focus-glow:rgba(56,189,248,.3);
       --card-bg:rgba(255,255,255,.06);
       --table-card-bg:rgba(255,255,255,.05);
       --table-border:rgba(255,255,255,.08);
@@ -164,6 +170,12 @@
       --input-border:rgba(148,163,184,.55);
       --input-focus-border:rgba(37,99,235,.5);
       --input-focus-shadow:rgba(37,99,235,.18);
+      --input-bg-top:rgba(255,255,255,.92);
+      --input-bg-bottom:rgba(226,232,240,.82);
+      --input-highlight:rgba(255,255,255,.9);
+      --input-lowlight:rgba(148,163,184,.28);
+      --input-shadow-raised:rgba(148,163,184,.22);
+      --input-focus-glow:rgba(59,130,246,.26);
       --card-bg:#ffffff;
       --table-card-bg:#ffffff;
       --table-border:rgba(226,232,240,.9);
@@ -454,9 +466,24 @@
     .form-grid .row{min-width:0}
     .span-2{grid-column:1 / -1}
     .row label{color:var(--ink-soft);font-size:13px;font-weight:600;letter-spacing:.04em;text-transform:uppercase}
-    input,select,textarea{width:100%;padding:14px;border:1px solid var(--input-border);border-radius:14px;background:var(--field);color:var(--ink);outline:none;transition:.15s;box-shadow:inset 0 1px 0 rgba(255,255,255,.06)}
+    input,select,textarea{
+      width:100%;
+      padding:14px;
+      border:1px solid var(--input-border);
+      border-radius:14px;
+      color:var(--ink);
+      outline:none;
+      background-color:var(--field);
+      background-image:linear-gradient(155deg,var(--input-bg-top),var(--input-bg-bottom));
+      transition:background-color .2s ease,border-color .2s ease,box-shadow .25s ease,color .2s ease;
+      box-shadow:inset 0 1px 0 var(--input-highlight),inset 0 -1px 0 var(--input-lowlight),0 8px 18px var(--input-shadow-raised);
+    }
     input::placeholder,textarea::placeholder{color:var(--muted)}
-    input:focus,select:focus,textarea:focus{border-color:var(--input-focus-border);background:var(--field-focus);box-shadow:0 0 0 3px var(--input-focus-shadow)}
+    input:focus,select:focus,textarea:focus{
+      border-color:var(--input-focus-border);
+      background-color:var(--field-focus);
+      box-shadow:0 0 0 1px var(--input-focus-border),0 0 0 4px var(--input-focus-glow),0 0 0 8px var(--input-focus-shadow),0 12px 24px var(--input-shadow-raised),inset 0 1px 0 var(--input-highlight),inset 0 -1px 0 var(--input-lowlight);
+    }
     textarea{min-height:88px;resize:vertical}
     .actions{display:flex;justify-content:center;gap:10px;margin-top:18px}
     .small{font-size:12px;color:var(--muted);text-align:center;margin-top:8px}
@@ -480,16 +507,37 @@
     .side-card .actions .btn{width:100%}
     .side-card .small{text-align:left;margin-top:0}
     .pin-wrap{position:relative}
-    .pin-wrap .eye{position:absolute;right:10px;top:50%;transform:translateY(-50%);border:1px solid var(--eye-border);background:var(--eye-bg);color:var(--ink);border-radius:10px;padding:6px 8px;cursor:pointer;transition:background-color .2s ease,border-color .2s ease}
-    .pin-wrap .eye:hover,.pin-wrap .eye:focus-visible{background:var(--ghost-hover-bg);border-color:var(--ghost-hover-border)}
-    .pin-wrap .eye:focus-visible{outline:2px solid rgba(125,211,252,.35);outline-offset:2px}
+    .pin-wrap .eye,
+    .email-toggle{
+      border:1px solid var(--eye-border);
+      background-color:var(--eye-bg);
+      background-image:linear-gradient(155deg,var(--input-bg-top),var(--input-bg-bottom));
+      color:var(--ink);
+      border-radius:10px;
+      padding:6px 8px;
+      cursor:pointer;
+      box-shadow:inset 0 1px 0 var(--input-highlight),inset 0 -1px 0 var(--input-lowlight),0 6px 12px var(--input-shadow-raised);
+      transition:background-color .2s ease,border-color .2s ease,box-shadow .25s ease,color .2s ease;
+    }
+    .pin-wrap .eye{position:absolute;right:10px;top:50%;transform:translateY(-50%)}
 
     /* email dropdown toggle */
     .row.suggestion-source{position:relative}
     .row.suggestion-source input{padding-right:44px}
-    .email-toggle{position:absolute;right:10px;top:50%;transform:translateY(-50%);border:1px solid var(--eye-border);background:var(--eye-bg);color:var(--ink);border-radius:10px;padding:6px 8px;cursor:pointer;line-height:1}
-    .email-toggle:hover,.email-toggle:focus-visible{background:var(--ghost-hover-bg);border-color:var(--ghost-hover-border)}
-    .email-toggle:focus-visible{outline:2px solid rgba(125,211,252,.35);outline-offset:2px}
+    .email-toggle{position:absolute;right:10px;top:50%;transform:translateY(-50%);line-height:1}
+    .pin-wrap .eye:hover,
+    .email-toggle:hover{
+      background-color:var(--field-focus);
+      border-color:var(--ghost-hover-border);
+      box-shadow:inset 0 1px 0 var(--input-highlight),inset 0 -1px 0 var(--input-lowlight),0 8px 16px var(--input-shadow-raised);
+    }
+    .pin-wrap .eye:focus-visible,
+    .email-toggle:focus-visible{
+      border-color:var(--input-focus-border);
+      background-color:var(--field-focus);
+      box-shadow:0 0 0 1px var(--input-focus-border),0 0 0 4px var(--input-focus-glow),0 0 0 8px var(--input-focus-shadow),0 8px 18px var(--input-shadow-raised),inset 0 1px 0 var(--input-highlight),inset 0 -1px 0 var(--input-lowlight);
+      outline:none;
+    }
 
     .linked-email-wrap{display:flex;gap:10px;align-items:center}
     .btn.icon-only{width:44px;height:44px;padding:0;display:flex;align-items:center;justify-content:center;font-size:24px;line-height:1}


### PR DESCRIPTION
## Resumen
- agrega variables de degradado y sombras para entradas en los modos oscuro y claro
- aplica el nuevo relieve con gradiente y halo luminoso a `input`, `select` y `textarea`
- actualiza los toggles de email y PIN para compartir el mismo lenguaje de profundidad

## Pruebas
- No se realizaron pruebas (no aplica)


------
https://chatgpt.com/codex/tasks/task_e_68d0d6c57634832ebb7a70b71f48dee9