### PR TITLE
Enhance Gemini chat markdown rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,8 +669,17 @@
     .chat-log{height:260px;overflow:auto;border:1px solid var(--border);border-radius:16px;padding:14px;background:var(--chat-log-bg);box-shadow:inset 0 1px 0 rgba(255,255,255,.04);backdrop-filter:blur(14px)}
     .chat-msg{margin:8px 0;display:flex}
     .chat-msg.user{justify-content:flex-end}
-    .chat-msg .bubble{max-width:85%;padding:10px 12px;border-radius:12px;white-space:pre-wrap}
-    .chat-msg.user .bubble{background:linear-gradient(135deg,#f28a2d,#f59e0b);color:#1a1205;border:1px solid rgba(255,255,255,.18);box-shadow:0 14px 32px rgba(242,138,45,.35)}
+    .chat-msg .bubble{max-width:85%;padding:10px 12px;border-radius:12px;white-space:normal;line-height:1.5}
+    .chat-msg .bubble p{margin:0}
+    .chat-msg .bubble p+p{margin-top:8px}
+    .chat-msg .bubble ul,
+    .chat-msg .bubble ol{margin:8px 0 0;padding-left:22px}
+    .chat-msg .bubble ul:first-child,
+    .chat-msg .bubble ol:first-child{margin-top:0}
+    .chat-msg .bubble li{margin:4px 0}
+    .chat-msg .bubble li>ul,
+    .chat-msg .bubble li>ol{margin-top:4px}
+    .chat-msg.user .bubble{background:linear-gradient(135deg,#f28a2d,#f59e0b);color:#1a1205;border:1px solid rgba(255,255,255,.18);box-shadow:0 14px 32px rgba(242,138,45,.35);white-space:pre-wrap}
     .chat-msg.ai .bubble{background:var(--ai-bubble-bg);border:1px solid var(--ai-bubble-border);color:var(--ink);box-shadow:0 10px 24px rgba(0,0,0,.4)}
 
     /* ===== Tokens de tema ===== */
@@ -989,6 +998,59 @@ let linkedHideTimeout=null;
 
 function toast(t){ msg.textContent=t; setTimeout(()=>msg.textContent='',2200); }
 function esc(s){return (s||'').replace(/[&<>"']/g,m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#039;' }[m]))}
+function renderMarkdown(input){
+  const safe = esc(input==null? '' : String(input));
+  if(!safe) return '';
+  const applyInline = (str)=>{
+    if(!str) return '';
+    let res = str;
+    res = res.replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>');
+    res = res.replace(/(^|[\s.,;:!?()"'¿¡-])_(.+?)_(?=[\s.,;:!?()"'¿¡-]|$)/g,(match,prefix,content)=>`${prefix}<em>${content}</em>`);
+    return res;
+  };
+  const lines = safe.split(/\r?\n/);
+  const blocks = [];
+  let paragraphLines=[];
+  let listType=null;
+  let listItems=[];
+  const flushParagraph=()=>{
+    if(!paragraphLines.length) return;
+    const text = paragraphLines.join(' ');
+    blocks.push(`<p>${text}</p>`);
+    paragraphLines=[];
+  };
+  const flushList=()=>{
+    if(!listType || !listItems.length){ listType=null; listItems=[]; return; }
+    blocks.push(`<${listType}>${listItems.map(item=>`<li>${item}</li>`).join('')}</${listType}>`);
+    listType=null;
+    listItems=[];
+  };
+  for(const rawLine of lines){
+    const trimmed = rawLine.trim();
+    if(!trimmed){ flushParagraph(); flushList(); continue; }
+    const unordered = trimmed.match(/^([-*])\s+(.+)/);
+    if(unordered){
+      flushParagraph();
+      const item = applyInline(unordered[2].trim());
+      if(listType!=='ul'){ flushList(); listType='ul'; }
+      listItems.push(item);
+      continue;
+    }
+    const ordered = trimmed.match(/^(\d+)[.)]\s+(.+)/);
+    if(ordered){
+      flushParagraph();
+      const item = applyInline(ordered[2].trim());
+      if(listType!=='ol'){ flushList(); listType='ol'; }
+      listItems.push(item);
+      continue;
+    }
+    flushList();
+    paragraphLines.push(applyInline(trimmed));
+  }
+  flushParagraph();
+  flushList();
+  return blocks.join('');
+}
 function fmt(iso){return iso? new Date(iso+'T00:00:00').toLocaleDateString(): '-'}
 
 /* ===== Tema ===== */
@@ -1769,7 +1831,18 @@ document.addEventListener('keydown',(e)=>{ if(e.key==='Escape') closeChat(); });
 
 function renderChat(){
   if(!chatLogEl) return;
-  chatLogEl.innerHTML = chatHistory.map(m=>`<div class="chat-msg ${m.role}"><div class="bubble">${esc(m.text)}</div></div>`).join('');
+  const html = chatHistory.map(m=>{
+    const role = m?.role || 'user';
+    let content;
+    if(role==='ai'){
+      const formatted = renderMarkdown(m?.text);
+      content = formatted || (m?.text ? `<p>${esc(m?.text)}</p>` : '');
+    }else{
+      content = esc(m?.text);
+    }
+    return `<div class="chat-msg ${role}"><div class="bubble">${content}</div></div>`;
+  }).join('');
+  chatLogEl.innerHTML = html;
   chatLogEl.scrollTop = chatLogEl.scrollHeight;
 }
 renderChat();


### PR DESCRIPTION
## Summary
- add a `renderMarkdown` helper that escapes user content before converting a safe subset of Markdown to HTML
- update chat rendering to format Gemini replies with the helper while keeping user messages escaped
- adjust chat bubble styles so paragraphs and lists render with comfortable spacing

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0e2aca510832e80a1a320b73e4922