### PR TITLE
Ajusta layout y estilos del modal de chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@
     .form-grid .row{min-width:0}
     .span-2{grid-column:1 / -1}
     .row label{color:var(--ink-soft);font-size:13px;font-weight:600;letter-spacing:.04em;text-transform:uppercase}
-    input,select,textarea{
+    input:not([type=checkbox]):not([type=radio]),select,textarea{
       width:100%;
       padding:14px;
       border:1px solid var(--input-border);
@@ -663,13 +663,41 @@
     }
     .modal header{display:flex;align-items:center;justify-content:space-between;padding:16px 18px;border-bottom:1px solid rgba(255,255,255,.08)}
     .modal .body{padding:16px 18px;color:var(--ink)}
+    .modal.chat-modal{
+      width:min(1100px,98vw);
+      height:min(90vh,840px);
+      max-height:90vh;
+      background:var(--modal-bg);
+      border:1px solid var(--border);
+      box-shadow:var(--shadow);
+      backdrop-filter:none;
+      overflow:hidden;
+    }
+    .modal.chat-modal header{display:flex;align-items:flex-start;justify-content:space-between;padding:26px 32px 20px;border-bottom:1px solid var(--border);background:var(--field);}
+    .modal.chat-modal header strong{
+      font-size:1.6rem;
+      font-weight:700;
+      letter-spacing:-0.01em;
+      color:var(--ink);
+    }
+    .modal.chat-modal .body{
+      flex:1;
+      display:flex;
+      flex-direction:column;
+      gap:24px;
+      padding:28px 32px 32px;
+      color:var(--ink);
+      background:var(--modal-bg);
+      overflow:hidden;
+    }
 
     /* ===== Chat (Gemini) ===== */
     .section-head{font-weight:700;margin-bottom:8px;color:var(--ink);text-shadow:0 10px 24px rgba(0,0,0,.45)}
-    .chat-log{height:260px;overflow:auto;border:1px solid var(--border);border-radius:16px;padding:14px;background:var(--chat-log-bg);box-shadow:inset 0 1px 0 rgba(255,255,255,.04);backdrop-filter:blur(14px)}
-    .chat-msg{margin:8px 0;display:flex}
+    .chat-log{flex:1;min-height:420px;max-height:calc(100% - 140px);overflow:auto;border:1px solid var(--border);border-radius:18px;padding:22px 24px;background:var(--field);display:flex;flex-direction:column;gap:14px;box-shadow:inset 0 1px 0 rgba(255,255,255,.04)}
+    .chat-modal .chat-log{background:var(--field);}
+    .chat-msg{margin:0;display:flex}
     .chat-msg.user{justify-content:flex-end}
-    .chat-msg .bubble{max-width:85%;padding:10px 12px;border-radius:12px;white-space:normal;line-height:1.5}
+    .chat-msg .bubble{max-width:85%;padding:12px 16px;border-radius:16px;white-space:normal;line-height:1.6;font-size:1rem}
     .chat-msg .bubble p{margin:0}
     .chat-msg .bubble p+p{margin-top:8px}
     .chat-msg .bubble ul,
@@ -690,8 +718,15 @@
     .chat-msg .bubble tbody td{padding:10px 12px;border-top:1px solid var(--table-border)}
     .chat-msg .bubble th,
     .chat-msg .bubble td{font-size:.95em;vertical-align:top}
-    .chat-msg.user .bubble{background:linear-gradient(135deg,#f28a2d,#f59e0b);color:#1a1205;border:1px solid rgba(255,255,255,.18);box-shadow:0 14px 32px rgba(242,138,45,.35);white-space:pre-wrap}
-    .chat-msg.ai .bubble{background:var(--ai-bubble-bg);border:1px solid var(--ai-bubble-border);color:var(--ink);box-shadow:0 10px 24px rgba(0,0,0,.4)}
+    .chat-msg.user .bubble{background:var(--btn);color:var(--btn-ink);border:1px solid rgba(255,255,255,.18);box-shadow:0 18px 34px rgba(242,138,45,.35);white-space:pre-wrap}
+    .chat-msg.ai .bubble{background:var(--ai-bubble-bg);border:1px solid var(--ai-bubble-border);color:var(--ink);box-shadow:0 14px 30px rgba(0,0,0,.42)}
+    .chat-modal .composer{display:grid;grid-template-columns:1fr auto;gap:12px;padding:20px 22px;border-radius:16px;border:1px solid var(--border);background:var(--field)}
+    .chat-modal .composer input{padding:14px 16px;font-size:1rem;border-radius:12px}
+    .chat-modal .composer button{min-width:120px;font-size:1rem;font-weight:600}
+    .chat-modal .body .small{margin:0;text-align:left;color:var(--muted)}
+    .chat-modal .chat-share{display:flex;align-items:center;gap:10px;font-size:13px}
+    .chat-modal .chat-share input{margin:0;width:auto;height:auto;accent-color:var(--btn);cursor:pointer}
+    .chat-modal .chat-note{font-size:12px;line-height:1.5}
 
     /* ===== Tokens de tema ===== */
     .sidebar-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:16px}
@@ -868,21 +903,19 @@
 
   <!-- ===== Modal Chat Gemini ===== -->
   <div id="chatModal" class="modal-backdrop" aria-hidden="true">
-    <div class="modal" role="dialog" aria-label="Chat Gemini">
+    <div class="modal chat-modal" role="dialog" aria-label="Chat Gemini">
       <header>
         <strong>Chat Gemini</strong>
         <button class="btn ghost" id="btnChatClose">Cerrar</button>
       </header>
       <div class="body">
         <div id="chatLog" class="chat-log"></div>
-        <div style="display:grid;grid-template-columns:1fr auto;gap:8px;margin-top:10px">
+        <div class="composer">
           <input id="chatInput" placeholder="Escribe un mensaje…"/>
           <button class="btn primary" id="btnSend">Enviar</button>
         </div>
-        <div class="small" style="text-align:left;margin-top:6px">
-          <label><input type="checkbox" id="shareSecrets"> Compartir datos sensibles (PIN y notas)</label>
-        </div>
-        <div class="small">Conexión directa a Gemini desde el navegador (API key expuesta).</div>
+        <label class="small chat-share"><input type="checkbox" id="shareSecrets"> Compartir datos sensibles (PIN y notas)</label>
+        <div class="small chat-note">Conexión directa a Gemini desde el navegador (API key expuesta).</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Resumen
- ampliar el modal de chat y aplicar fondo plano con encabezado más destacado
- convertir el cuerpo del modal en un layout flex para que el historial se expanda de forma dinámica
- refactorizar los controles del chat con nueva rejilla del compositor y casilla de verificación estilizada
- evitar que el estilo global de inputs afecte a los checkboxes

## Pruebas
- no se realizaron pruebas automatizadas (html estático)


------
https://chatgpt.com/codex/tasks/task_e_68d0e8fd0c28832e91c8e7d3648591d1