### PR TITLE
Show welcome message when chat is empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -709,6 +709,11 @@
     .section-head{font-weight:700;margin-bottom:8px;color:var(--ink);text-shadow:0 10px 24px rgba(0,0,0,.45)}
     .chat-log{flex:1;min-height:420px;max-height:calc(100% - 140px);overflow:auto;border:1px solid var(--border);border-radius:18px;padding:22px 24px;background:var(--field);display:flex;flex-direction:column;gap:14px;box-shadow:inset 0 1px 0 rgba(255,255,255,.04)}
     .chat-modal .chat-log{background:var(--field);}
+    .chat-log.is-empty{justify-content:center;align-items:center;gap:0;text-align:center;padding:32px 40px;}
+    .chat-empty{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;max-width:420px;margin:0 auto;color:var(--muted);line-height:1.6;}
+    .chat-empty .chat-empty-emoji{font-size:2.4rem;line-height:1;}
+    .chat-empty h3{margin:0;font-size:1.45rem;font-weight:700;color:var(--ink);letter-spacing:-0.01em;}
+    .chat-empty p{margin:0;font-size:1.05rem;color:var(--muted);}
     .chat-msg{margin:0;display:flex}
     .chat-msg.user{justify-content:flex-end}
     .chat-msg .bubble{max-width:85%;padding:12px 16px;border-radius:16px;white-space:normal;line-height:1.6;font-size:1rem}
@@ -1956,6 +1961,19 @@ document.addEventListener('keydown',(e)=>{ if(e.key==='Escape') closeChat(); });
 
 function renderChat(){
   if(!chatLogEl) return;
+  if(!Array.isArray(chatHistory) || chatHistory.length===0){
+    chatLogEl.classList.add('is-empty');
+    chatLogEl.innerHTML = `
+      <div class="chat-empty">
+        <span class="chat-empty-emoji" aria-hidden="true">🤖</span>
+        <h3>¡Hola! Soy Zyl0</h3>
+        <p>Estoy listo para ayudarte. Escribe tu consulta para iniciar la conversación.</p>
+      </div>
+    `;
+    chatLogEl.scrollTop = 0;
+    return;
+  }
+  chatLogEl.classList.remove('is-empty');
   const html = chatHistory.map(m=>{
     const role = m?.role || 'user';
     const isKnownRole = role==='user' || role==='ai';


### PR DESCRIPTION
## Summary
- render a dedicated empty-state message when the chat history has no entries
- add styling for the empty-state block to match the intended centered welcome design

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d17bfeafe8832e8f41d1a34e45b0d7