### PR TITLE
Add hero load animation and load handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,10 +136,12 @@
       --launcher-highlight-active:rgba(255,255,255,.34);
       --tag-border:rgba(255,255,255,.2);
       --tag-bg:rgba(255,255,255,.05);
+      --hero-opacity:0;
     }
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
     html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
-    body{position:relative;min-height:100vh;overflow-x:hidden;padding-left:0;transition:padding-left .3s ease}
+    body{position:relative;min-height:100vh;overflow-x:hidden;padding-left:0;transition:padding-left .3s ease;--hero-opacity:0}
+    body.page-loaded{--hero-opacity:1}
     body::before{
       content:"";
       position:fixed;
@@ -151,7 +153,10 @@
       z-index:-1;
       filter:blur(12px);
       transform:scale(1.06);
+      opacity:var(--hero-opacity);
+      transition:opacity .6s ease,transform .6s ease,filter .6s ease;
     }
+    body.page-loaded::before{filter:none;transform:scale(1)}
     body.theme-light{
       color-scheme:light;
       --bg:#f8fafc; --ink:#0f172a; --ink-soft:#1e293b; --muted:#475569;
@@ -417,7 +422,7 @@
 
     /* ===== Layout ===== */
     #Header,#BarraServicio,#AppGrid{width:min(1200px,92vw);margin:0 auto}
-    #Header{padding:36px 18px 0;position:relative;z-index:0}
+    #Header{padding:36px 18px 0;position:relative;z-index:0;opacity:var(--hero-opacity);transform:translateY(24px);filter:blur(8px);transition:opacity .55s ease,transform .55s ease,filter .55s ease}
     #BarraServicio{padding:0 18px}
     #AppGrid{padding:0 18px 80px;margin-top:32px;display:grid;grid-template-columns:minmax(0,1fr);grid-template-areas:"form" "acciones" "tabla";gap:24px}
     #Formulario{grid-area:form}
@@ -427,7 +432,11 @@
       #AppGrid{grid-template-columns:minmax(0,2fr)minmax(0,1fr);grid-template-areas:"form acciones" "tabla tabla";}
     }
     .pill{display:block;width:max-content;margin:0 auto 14px;padding:6px 14px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid var(--border);font-size:12px;letter-spacing:.08em;text-transform:uppercase}
-    .hero-brand{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:clamp(12px,3vw,28px);margin:6px 0 24px;text-align:center}
+    #Header .pill{opacity:var(--hero-opacity);transform:translateY(18px);filter:blur(6px);transition:opacity .5s ease,transform .5s ease,filter .5s ease;transition-delay:.05s}
+    .hero-brand{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:clamp(12px,3vw,28px);margin:6px 0 24px;text-align:center;opacity:var(--hero-opacity);transform:translateY(28px);filter:blur(8px);transition:opacity .6s ease,transform .6s ease,filter .6s ease;transition-delay:.12s}
+    body.page-loaded #Header,
+    body.page-loaded .hero-brand,
+    body.page-loaded #Header .pill{opacity:var(--hero-opacity);transform:none;filter:none}
     .hero-brand img{width:clamp(64px,16vw,132px);height:auto;flex-shrink:0;filter:drop-shadow(0 18px 36px rgba(0,0,0,.55));border-radius:24px}
     .hero-brand span{display:block;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(54px,16vw,144px);line-height:.95;text-shadow:0 12px 32px rgba(0,0,0,.55);text-transform:uppercase}
     @media(max-width:520px){
@@ -2192,6 +2201,11 @@ filterEstado?.addEventListener('change', () => renderTabla());
 })();
 
 /* inicio */
+if(document.readyState==='complete'){
+  document.body.classList.add('page-loaded');
+} else {
+  window.addEventListener('load', () => document.body.classList.add('page-loaded'));
+}
 renderServicios().then(()=>renderTabla());
 </script>
 </body>


### PR DESCRIPTION
## Summary
- choreograph the hero header, brand badge, and background using a shared `--hero-opacity` transition
- toggle the animated state once the window load event fires, with a `readyState` fallback before rendering data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d183429f24832eb39fa39a196240eb