### PR TITLE
Add scroll fade effects for hero and sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@
       --tag-border:rgba(255,255,255,.2);
       --tag-bg:rgba(255,255,255,.05);
       --hero-opacity:0;
+      --hero-fade:1;
     }
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
     html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
@@ -154,6 +155,7 @@
       filter:blur(12px);
       transform:scale(1.06);
       opacity:var(--hero-opacity);
+      opacity:calc(var(--hero-opacity) * var(--hero-fade));
       transition:opacity .6s ease,transform .6s ease,filter .6s ease;
     }
     body.page-loaded::before{filter:none;transform:scale(1)}
@@ -422,7 +424,7 @@
 
     /* ===== Layout ===== */
     #Header,#BarraServicio,#AppGrid{width:min(1200px,92vw);margin:0 auto}
-    #Header{padding:36px 18px 0;position:relative;z-index:0;opacity:var(--hero-opacity);transform:translateY(24px);filter:blur(8px);transition:opacity .55s ease,transform .55s ease,filter .55s ease}
+    #Header{padding:36px 18px 0;position:relative;z-index:0;opacity:var(--hero-opacity);opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:translateY(24px);filter:blur(8px);transition:opacity .55s ease,transform .55s ease,filter .55s ease}
     #BarraServicio{padding:0 18px}
     #AppGrid{padding:0 18px 80px;margin-top:32px;display:grid;grid-template-columns:minmax(0,1fr);grid-template-areas:"form" "acciones" "tabla";gap:24px}
     #Formulario{grid-area:form}
@@ -432,11 +434,14 @@
       #AppGrid{grid-template-columns:minmax(0,2fr)minmax(0,1fr);grid-template-areas:"form acciones" "tabla tabla";}
     }
     .pill{display:block;width:max-content;margin:0 auto 14px;padding:6px 14px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid var(--border);font-size:12px;letter-spacing:.08em;text-transform:uppercase}
-    #Header .pill{opacity:var(--hero-opacity);transform:translateY(18px);filter:blur(6px);transition:opacity .5s ease,transform .5s ease,filter .5s ease;transition-delay:.05s}
-    .hero-brand{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:clamp(12px,3vw,28px);margin:6px 0 24px;text-align:center;opacity:var(--hero-opacity);transform:translateY(28px);filter:blur(8px);transition:opacity .6s ease,transform .6s ease,filter .6s ease;transition-delay:.12s}
+    #Header .pill{opacity:var(--hero-opacity);opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:translateY(18px);filter:blur(6px);transition:opacity .5s ease,transform .5s ease,filter .5s ease;transition-delay:.05s}
+    .hero-brand{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:clamp(12px,3vw,28px);margin:6px 0 24px;text-align:center;opacity:var(--hero-opacity);opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:translateY(28px);filter:blur(8px);transition:opacity .6s ease,transform .6s ease,filter .6s ease;transition-delay:.12s}
     body.page-loaded #Header,
     body.page-loaded .hero-brand,
-    body.page-loaded #Header .pill{opacity:var(--hero-opacity);transform:none;filter:none}
+    body.page-loaded #Header .pill{opacity:var(--hero-opacity);opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:none;filter:none}
+    .fade-scroll-target{opacity:1;transform:none;filter:none;transition:opacity .6s ease,transform .6s ease,filter .6s ease;will-change:opacity,transform,filter}
+    .fade-scroll-target.is-hidden{opacity:0;transform:translateY(32px);filter:blur(12px)}
+    .fade-scroll-target.is-visible{opacity:1;transform:none;filter:none}
     .hero-brand img{width:clamp(64px,16vw,132px);height:auto;flex-shrink:0;filter:drop-shadow(0 18px 36px rgba(0,0,0,.55));border-radius:24px}
     .hero-brand span{display:block;font-weight:800;letter-spacing:-0.02em;color:var(--ink);font-size:clamp(54px,16vw,144px);line-height:.95;text-shadow:0 12px 32px rgba(0,0,0,.55);text-transform:uppercase}
     @media(max-width:520px){
@@ -860,7 +865,7 @@
   </section>
 
   <main id="AppGrid">
-    <section id="Formulario" class="form">
+    <section id="Formulario" class="form fade-scroll-target is-hidden">
       <div class="form-grid">
         <div class="row">
           <label for="nombre">Nombre</label>
@@ -910,7 +915,7 @@
       </div>
     </section>
 
-    <aside id="AccionesRapidas" class="side-card">
+    <aside id="AccionesRapidas" class="side-card fade-scroll-target is-hidden">
       <h2>Acciones rápidas</h2>
       <p>Guarda el nuevo cliente o limpia el formulario antes de continuar.</p>
       <div class="actions">
@@ -921,7 +926,7 @@
     </aside>
 
     <!-- tabla -->
-    <section id="TablaClientes" class="table-section">
+    <section id="TablaClientes" class="table-section fade-scroll-target is-hidden">
       <div class="table-header">
         <h2 id="clientesTitulo">Clientes registrados</h2>
         <p>Consulta el listado completo y gestiona cada registro.</p>
@@ -1049,6 +1054,84 @@ categoria:$('#categoria'), pin:$('#pin')};
 const q=$('#q'), filterEstado=$('#filterEstado'), msg=$('#msg');
 const sidebar=document.getElementById('sidebar');
 const sidebarLauncher=document.getElementById('sidebarLauncher');
+const hero=document.getElementById('Header');
+const scrollFadeTargets=['Formulario','AccionesRapidas','TablaClientes'].map(id=>document.getElementById(id)).filter(Boolean);
+const docEl=document.documentElement;
+const supportsIntersectionObserver='IntersectionObserver'in window;
+let heroFadeDistance=1;
+let lastHeroFade=null;
+let lastHeroInlineFade=null;
+
+function computeHeroFadeDistance(){
+  if(!hero) return Math.max((window.innerHeight||docEl.clientHeight||1)*.6,160);
+  const rect=hero.getBoundingClientRect();
+  const height=Math.max(rect.height||0,hero.offsetHeight||0,1);
+  return Math.max(height*1.2,180);
+}
+function setSectionVisibility(el,visible){
+  if(!el) return;
+  el.classList.toggle('is-visible',visible);
+  el.classList.toggle('is-hidden',!visible);
+}
+let legacyRevealCheck=null;
+if(supportsIntersectionObserver&&typeof IntersectionObserver==='function'){
+  const observer=new IntersectionObserver(entries=>{
+    entries.forEach(entry=> setSectionVisibility(entry.target,entry.isIntersecting));
+  },{threshold:.2,rootMargin:'0px 0px -10% 0px'});
+  scrollFadeTargets.forEach(el=>observer.observe(el));
+}else if(scrollFadeTargets.length){
+  legacyRevealCheck=()=>{
+    const viewportHeight=window.innerHeight||docEl.clientHeight||0;
+    const upper=viewportHeight*.15;
+    const lower=viewportHeight*.9;
+    scrollFadeTargets.forEach(el=>{
+      const rect=el.getBoundingClientRect();
+      const visible=rect.bottom>upper && rect.top<lower;
+      setSectionVisibility(el,visible);
+    });
+  };
+}
+function applyHeroFade(){
+  if(!hero){
+    docEl.style.setProperty('--hero-fade','1');
+    return;
+  }
+  const distance=heroFadeDistance||1;
+  const scrollTop=window.scrollY!=null?window.scrollY:(window.pageYOffset||0);
+  const fadeValue=Math.max(0,Math.min(1,1-(scrollTop/distance)));
+  const fadeRounded=Math.round(fadeValue*1000)/1000;
+  if(lastHeroFade!==fadeRounded){
+    docEl.style.setProperty('--hero-fade',fadeRounded.toString());
+    lastHeroFade=fadeRounded;
+  }
+  if(!document.body.classList.contains('page-loaded')){
+    lastHeroInlineFade=null;
+    return;
+  }
+  if(lastHeroInlineFade===fadeRounded) return;
+  hero.style.opacity=fadeRounded.toString();
+  const blur=Math.max(0,(1-fadeRounded)*8);
+  hero.style.filter=fadeRounded>=.999?'none':`blur(${blur.toFixed(2)}px)`;
+  const offset=Math.max(0,(1-fadeRounded)*24);
+  hero.style.transform=fadeRounded>=.999?'none':`translateY(${offset.toFixed(1)}px)`;
+  lastHeroInlineFade=fadeRounded;
+}
+function handleScrollEffects(){
+  applyHeroFade();
+  if(legacyRevealCheck) legacyRevealCheck();
+}
+function recalcHeroFadeDistance(){
+  heroFadeDistance=computeHeroFadeDistance();
+}
+recalcHeroFadeDistance();
+handleScrollEffects();
+window.addEventListener('scroll',handleScrollEffects,{passive:true});
+window.addEventListener('resize',()=>{recalcHeroFadeDistance();handleScrollEffects();});
+window.addEventListener('load',()=>{
+  recalcHeroFadeDistance();
+  handleScrollEffects();
+  if(typeof requestAnimationFrame==='function'){requestAnimationFrame(handleScrollEffects);}else{setTimeout(handleScrollEffects,0);}
+});
 
 const themeButton=document.getElementById('btnTheme');
 const themeLabel=document.getElementById('themeLabel');


### PR DESCRIPTION
## Summary
- add a `--hero-fade` CSS variable plus fade utility classes and apply them to the main sections so they animate into view
- implement a scroll handler that updates the hero fade effect, coordinates the body backdrop, and reveals sections via IntersectionObserver with a legacy fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d186cc47e8832e98741aa3d4f50053