### PR TITLE
Reestructura secciones principales y actualiza diseño

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,22 +423,68 @@
     .linklike:active::after{transform:scaleX(1)}
 
     /* ===== Layout ===== */
-    #Header,#BarraServicio,#AppGrid{width:min(1200px,92vw);margin:0 auto}
-    #Header{padding:36px 18px 0;position:relative;z-index:0;opacity:var(--hero-opacity);opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:translateY(24px);filter:blur(8px);transition:opacity .55s ease,transform .55s ease,filter .55s ease}
-    #BarraServicio{padding:0 18px}
-    #AppGrid{padding:0 18px 80px;margin-top:32px;display:grid;grid-template-columns:minmax(0,1fr);grid-template-areas:"form" "acciones" "tabla";gap:24px}
-    #Formulario{grid-area:form}
-    #AccionesRapidas{grid-area:acciones}
-    #TablaClientes{grid-area:tabla;margin-top:0}
+    #Hero,#Registro,#TablaClientes{
+      width:min(1200px,92vw);
+      margin:0 auto;
+      min-height:100vh;
+      padding:36px 18px;
+      display:flex;
+      flex-direction:column;
+      justify-content:center;
+      align-items:center;
+      gap:32px;
+    }
+    #Hero{
+      position:relative;
+      z-index:0;
+      text-align:center;
+      padding-bottom:0;
+    }
+    .hero-section{
+      opacity:calc(var(--hero-opacity)*var(--hero-fade));
+      transform:translateY(24px);
+      filter:blur(8px);
+      transition:opacity .55s ease,transform .55s ease,filter .55s ease;
+    }
+    .hero-section .pill{
+      opacity:calc(var(--hero-opacity)*var(--hero-fade));
+      transform:translateY(18px);
+      filter:blur(6px);
+      transition:opacity .5s ease,transform .5s ease,filter .5s ease;
+      transition-delay:.05s;
+    }
+    #Registro{
+      align-items:stretch;
+    }
+    #TablaClientes{
+      align-items:stretch;
+      padding-bottom:80px;
+    }
+    #BarraServicio{
+      display:flex;
+      justify-content:center;
+      align-items:center;
+      gap:10px;
+      flex-wrap:wrap;
+      margin:0;
+    }
+    .registration-columns{
+      display:flex;
+      flex-direction:column;
+      gap:24px;
+      width:100%;
+    }
+    #Formulario,#AccionesRapidas{width:100%;}
     @media(min-width:960px){
-      #AppGrid{grid-template-columns:minmax(0,2fr)minmax(0,1fr);grid-template-areas:"form acciones" "tabla tabla";}
+      .registration-columns{flex-direction:row;align-items:flex-start;}
+      #Formulario{flex:2;}
+      #AccionesRapidas{flex:1;}
     }
     .pill{display:block;width:max-content;margin:0 auto 14px;padding:6px 14px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid var(--border);font-size:12px;letter-spacing:.08em;text-transform:uppercase}
-    #Header .pill{opacity:var(--hero-opacity);opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:translateY(18px);filter:blur(6px);transition:opacity .5s ease,transform .5s ease,filter .5s ease;transition-delay:.05s}
-    .hero-brand{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:clamp(12px,3vw,28px);margin:6px 0 24px;text-align:center;opacity:var(--hero-opacity);opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:translateY(28px);filter:blur(8px);transition:opacity .6s ease,transform .6s ease,filter .6s ease;transition-delay:.12s}
-    body.page-loaded #Header,
-    body.page-loaded .hero-brand,
-    body.page-loaded #Header .pill{opacity:var(--hero-opacity);opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:none;filter:none}
+    .hero-brand{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:clamp(12px,3vw,28px);margin:6px 0 24px;text-align:center;opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:translateY(28px);filter:blur(8px);transition:opacity .6s ease,transform .6s ease,filter .6s ease;transition-delay:.12s}
+    body.page-loaded .hero-section,
+    body.page-loaded .hero-section .hero-brand,
+    body.page-loaded .hero-section .pill{opacity:calc(var(--hero-opacity)*var(--hero-fade));transform:none;filter:none}
     .fade-scroll-target{opacity:1;transform:none;filter:none;transition:opacity .6s ease,transform .6s ease,filter .6s ease;will-change:opacity,transform,filter}
     .fade-scroll-target.is-hidden{opacity:0;transform:translateY(32px);filter:blur(12px)}
     .fade-scroll-target.is-visible{opacity:1;transform:none;filter:none}
@@ -579,7 +625,7 @@
     .suggestion-empty{padding:12px 16px;color:var(--muted);font-size:13px}
 
     /* ===== Tabla ===== */
-    .table-section{margin-top:40px;display:flex;flex-direction:column;gap:18px}
+    .table-section{display:flex;flex-direction:column;gap:18px;width:100%}
     .table-header{display:flex;flex-direction:column;gap:6px}
     @media(min-width:720px){
       .table-header{flex-direction:row;align-items:flex-end;justify-content:space-between}
@@ -849,84 +895,86 @@
     </div>
   </aside>
 
-  <header id="Header">
-    <span class="pill">importante</span>
-    <div class="hero-brand" role="heading" aria-level="1">
-      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%237dd3fc'/%3E%3Cstop offset='55%25' stop-color='%2316f2a6'/%3E%3Cstop offset='100%25' stop-color='%23f28a2d'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath fill='url(%23g)' d='M98.7 22.3C70.8 12.7 38.5 18.4 22.9 41.3 7.3 64.1 6.9 96 33 96c23.2 0 46.4-23.4 57.4-48.6 5.5-12.7 7.7-23.5 8.3-25.1Z'/%3E%3Cpath fill='none' stroke='rgba(255,255,255,0.6)' stroke-width='6' stroke-linecap='round' d='M36 74c16-8 36-28 47-50'/%3E%3C/svg%3E" alt="Hoja Super Zylo" loading="lazy"/>
-      <span>Super Zylo</span>
-    </div>
-  </header>
-
-  <section id="BarraServicio" class="center">
-    <div class="label">Servicio</div>
-    <select id="servicio" style="max-width:260px"></select>
-    <button id="btnAgregarServicio" class="addserv" aria-label="Agregar servicio" title="Agregar servicio">+</button>
-    <button id="btnEliminarServicio" class="addserv remove" aria-label="Eliminar servicio" title="Eliminar servicio">−</button>
-  </section>
-
-  <main id="AppGrid">
-    <section id="Formulario" class="form fade-scroll-target is-hidden">
-      <div class="form-grid">
-        <div class="row">
-          <label for="nombre">Nombre</label>
-          <input id="nombre" placeholder="Escribe"/>
-        </div>
-
-        <!-- EMAIL con dropdown contextual por servicio -->
-        <div class="row suggestion-source">
-          <label for="email">Email</label>
-          <input id="email" type="email" placeholder="ej: cliente@mail.com" aria-expanded="false" aria-controls="emailSuggestionDropdown" />
-          <button class="email-toggle" id="emailDropdownToggle" type="button" aria-label="Mostrar correos guardados">▾</button>
-          <div id="emailSuggestionDropdown" class="suggestion-dropdown" role="listbox" aria-hidden="true"></div>
-        </div>
-
-        <div class="row">
-          <label for="telefono">Teléfono</label>
-          <input id="telefono" placeholder="+51 …"/>
-        </div>
-        <div class="row">
-          <label for="inicio">Fecha</label>
-          <input id="inicio" type="date" />
-        </div>
-        <div class="row">
-          <label for="vence">Vence</label>
-          <input id="vence" type="date" />
-        </div>
-        <div class="row">
-          <label for="pin">PIN</label>
-          <div class="pin-wrap">
-            <input id="pin" type="password" inputmode="numeric" pattern="[0-9]*" placeholder="••••" />
-            <button type="button" class="eye" id="togglePin" aria-label="Mostrar/ocultar PIN">👁</button>
-          </div>
-        </div>
-        <div class="row">
-          <label for="categoria">Categoría</label>
-          <select id="categoria">
-            <option value="">Selecciona una opción</option>
-            <option>Premium</option>
-            <option>Estándar</option>
-            <option>Básico</option>
-          </select>
-        </div>
-        <div class="row span-2">
-          <label for="notas">Notas</label>
-          <textarea id="notas" placeholder="Plan, precio, usuario, etc."></textarea>
-        </div>
+  <main id="MainContent">
+    <section id="Hero" class="page-section hero-section fade-scroll-target is-hidden">
+      <span class="pill">importante</span>
+      <div class="hero-brand" role="heading" aria-level="1">
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%237dd3fc'/%3E%3Cstop offset='55%25' stop-color='%2316f2a6'/%3E%3Cstop offset='100%25' stop-color='%23f28a2d'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath fill='url(%23g)' d='M98.7 22.3C70.8 12.7 38.5 18.4 22.9 41.3 7.3 64.1 6.9 96 33 96c23.2 0 46.4-23.4 57.4-48.6 5.5-12.7 7.7-23.5 8.3-25.1Z'/%3E%3Cpath fill='none' stroke='rgba(255,255,255,0.6)' stroke-width='6' stroke-linecap='round' d='M36 74c16-8 36-28 47-50'/%3E%3C/svg%3E" alt="Hoja Super Zylo" loading="lazy"/>
+        <span>Super Zylo</span>
       </div>
     </section>
 
-    <aside id="AccionesRapidas" class="side-card fade-scroll-target is-hidden">
-      <h2>Acciones rápidas</h2>
-      <p>Guarda el nuevo cliente o limpia el formulario antes de continuar.</p>
-      <div class="actions">
-        <button class="btn primary" id="btnGuardar">Agregar</button>
-        <button class="btn ghost" id="btnLimpiar">Limpiar</button>
+    <section id="Registro" class="page-section registration-section fade-scroll-target is-hidden">
+      <div id="BarraServicio" class="center service-bar">
+        <div class="label">Servicio</div>
+        <select id="servicio" style="max-width:260px"></select>
+        <button id="btnAgregarServicio" class="addserv" aria-label="Agregar servicio" title="Agregar servicio">+</button>
+        <button id="btnEliminarServicio" class="addserv remove" aria-label="Eliminar servicio" title="Eliminar servicio">−</button>
       </div>
-      <div class="small" id="msg"></div>
-    </aside>
+      <div class="registration-columns">
+        <section id="Formulario" class="form">
+          <div class="form-grid">
+            <div class="row">
+              <label for="nombre">Nombre</label>
+              <input id="nombre" placeholder="Escribe"/>
+            </div>
 
-    <!-- tabla -->
-    <section id="TablaClientes" class="table-section fade-scroll-target is-hidden">
+            <!-- EMAIL con dropdown contextual por servicio -->
+            <div class="row suggestion-source">
+              <label for="email">Email</label>
+              <input id="email" type="email" placeholder="ej: cliente@mail.com" aria-expanded="false" aria-controls="emailSuggestionDropdown" />
+              <button class="email-toggle" id="emailDropdownToggle" type="button" aria-label="Mostrar correos guardados">▾</button>
+              <div id="emailSuggestionDropdown" class="suggestion-dropdown" role="listbox" aria-hidden="true"></div>
+            </div>
+
+            <div class="row">
+              <label for="telefono">Teléfono</label>
+              <input id="telefono" placeholder="+51 …"/>
+            </div>
+            <div class="row">
+              <label for="inicio">Fecha</label>
+              <input id="inicio" type="date" />
+            </div>
+            <div class="row">
+              <label for="vence">Vence</label>
+              <input id="vence" type="date" />
+            </div>
+            <div class="row">
+              <label for="pin">PIN</label>
+              <div class="pin-wrap">
+                <input id="pin" type="password" inputmode="numeric" pattern="[0-9]*" placeholder="••••" />
+                <button type="button" class="eye" id="togglePin" aria-label="Mostrar/ocultar PIN">👁</button>
+              </div>
+            </div>
+            <div class="row">
+              <label for="categoria">Categoría</label>
+              <select id="categoria">
+                <option value="">Selecciona una opción</option>
+                <option>Premium</option>
+                <option>Estándar</option>
+                <option>Básico</option>
+              </select>
+            </div>
+            <div class="row span-2">
+              <label for="notas">Notas</label>
+              <textarea id="notas" placeholder="Plan, precio, usuario, etc."></textarea>
+            </div>
+          </div>
+        </section>
+
+        <aside id="AccionesRapidas" class="side-card">
+          <h2>Acciones rápidas</h2>
+          <p>Guarda el nuevo cliente o limpia el formulario antes de continuar.</p>
+          <div class="actions">
+            <button class="btn primary" id="btnGuardar">Agregar</button>
+            <button class="btn ghost" id="btnLimpiar">Limpiar</button>
+          </div>
+          <div class="small" id="msg"></div>
+        </aside>
+      </div>
+    </section>
+
+    <section id="TablaClientes" class="page-section table-section fade-scroll-target is-hidden">
       <div class="table-header">
         <h2 id="clientesTitulo">Clientes registrados</h2>
         <p>Consulta el listado completo y gestiona cada registro.</p>
@@ -1054,8 +1102,8 @@ categoria:$('#categoria'), pin:$('#pin')};
 const q=$('#q'), filterEstado=$('#filterEstado'), msg=$('#msg');
 const sidebar=document.getElementById('sidebar');
 const sidebarLauncher=document.getElementById('sidebarLauncher');
-const hero=document.getElementById('Header');
-const scrollFadeTargets=['Formulario','AccionesRapidas','TablaClientes'].map(id=>document.getElementById(id)).filter(Boolean);
+const hero=document.getElementById('Hero');
+const scrollFadeTargets=['Hero','Registro','TablaClientes'].map(id=>document.getElementById(id)).filter(Boolean);
 const docEl=document.documentElement;
 const supportsIntersectionObserver='IntersectionObserver'in window;
 let heroFadeDistance=1;
@@ -1072,6 +1120,12 @@ function setSectionVisibility(el,visible){
   if(!el) return;
   el.classList.toggle('is-visible',visible);
   el.classList.toggle('is-hidden',!visible);
+  if(el===hero && !visible){
+    hero.style.opacity='';
+    hero.style.filter='';
+    hero.style.transform='';
+    lastHeroInlineFade=null;
+  }
 }
 let legacyRevealCheck=null;
 if(supportsIntersectionObserver&&typeof IntersectionObserver==='function'){


### PR DESCRIPTION
## Summary
- reorganize the hero, registration and client table into standalone sections with shared fade handling
- replace the grid layout with flex-based sections that occupy the viewport and center their content
- update the scroll reveal targets to match the new structure and reset the hero animation when hidden

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d192b89ce4832ea89e79933cc5d6fd