### PR TITLE
Revamp chat composer styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,59 +754,75 @@
     .chat-modal .composer{
       display:flex;
       align-items:center;
-      gap:12px;
-      padding:12px 14px;
-      border-radius:12px;
-      border:1px solid #dce1f0;
-      background:rgba(15,23,42,.04);
+      gap:0;
+      padding:10px 16px;
+      border-radius:999px;
+      border:1px solid rgba(236,236,241,.22);
+      background:rgba(236,236,241,.08);
       color:var(--chat-text);
+      box-shadow:0 10px 28px rgba(8,12,20,.25);
+      transition:border-color .2s ease,box-shadow .2s ease,background-color .2s ease;
+    }
+    .chat-modal .composer:focus-within{
+      border-color:var(--chat-accent);
+      box-shadow:0 0 0 3px rgba(16,163,127,.28);
+      background:rgba(236,236,241,.12);
     }
     .chat-modal .composer textarea{
       flex:1;
-      padding:12px 16px;
+      padding:0;
+      margin:0;
       font-size:1rem;
-      border-radius:10px;
       line-height:1.45;
       min-height:48px;
       max-height:220px;
       resize:none;
       overflow-y:hidden;
-      background:#ffffff;
-      border:1px solid #cbd5e1;
-      color:#0f172a;
-      box-shadow:inset 0 1px 2px rgba(15,23,42,.08);
-      transition:border-color .2s ease,box-shadow .2s ease,background-color .2s ease;
+      background:transparent;
+      border:0;
+      color:inherit;
+      box-shadow:none;
+      transition:color .2s ease;
     }
-    .chat-modal .composer textarea::placeholder{color:rgba(15,23,42,.45)}
-    .chat-modal .composer textarea:focus{
-      border-color:var(--chat-accent);
-      box-shadow:0 0 0 2px rgba(16,163,127,.35);
-      background:#ffffff;
+    .chat-modal .composer textarea::placeholder{color:rgba(236,236,241,.6)}
+    .chat-modal .composer textarea:focus,
+    .chat-modal .composer textarea:focus-visible{
+      outline:0;
     }
     .chat-modal .composer button{
-      min-width:110px;
-      padding:12px 20px;
-      font-size:1rem;
-      font-weight:600;
+      --composer-btn-bg:#111111;
+      --composer-btn-bg-hover:#000000;
+      --composer-btn-bg-active:#1f2937;
+      --composer-btn-color:#ffffff;
+      width:42px;
+      height:42px;
+      margin-left:12px;
+      padding:0;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
       border:0;
-      border-radius:10px;
-      color:#ffffff;
-      background:linear-gradient(135deg,#0dac7e,#07966b);
-      box-shadow:0 12px 24px rgba(7,150,107,.25);
+      border-radius:50%;
+      background:var(--composer-btn-bg);
+      color:var(--composer-btn-color);
+      box-shadow:0 12px 26px rgba(0,0,0,.3);
       cursor:pointer;
-      transition:transform .15s ease,box-shadow .15s ease,filter .15s ease;
+      font-size:18px;
+      line-height:1;
+      transition:background-color .2s ease,color .2s ease,transform .15s ease,box-shadow .2s ease;
     }
     .chat-modal .composer button:hover{
-      box-shadow:0 14px 28px rgba(7,150,107,.28);
+      background:var(--composer-btn-bg-hover);
       transform:translateY(-1px);
+      box-shadow:0 16px 32px rgba(8,12,20,.3);
     }
     .chat-modal .composer button:active{
-      box-shadow:0 10px 20px rgba(7,150,107,.22);
+      background:var(--composer-btn-bg-active);
       transform:translateY(0);
-      filter:brightness(.96);
+      box-shadow:0 8px 18px rgba(8,12,20,.26);
     }
     .chat-modal .composer button:focus-visible{
-      outline:3px solid rgba(13,172,126,.45);
+      outline:3px solid rgba(125,211,252,.65);
       outline-offset:2px;
     }
     .chat-modal .body .small{margin:0;text-align:left;color:var(--muted)}
@@ -814,12 +830,35 @@
     .chat-modal .chat-share input{margin:0;width:auto;height:auto;accent-color:var(--chat-accent);cursor:pointer;transition:box-shadow .2s ease}
     .chat-modal .chat-share input:hover{box-shadow:0 0 0 3px rgba(16,163,127,.25);border-radius:4px}
     .chat-modal .chat-share input:focus-visible{outline:2px solid rgba(16,163,127,.6);outline-offset:2px;border-radius:4px}
-    body.theme-light .chat-modal .composer{background:#f8fafc;border-color:#dce1f0}
+    body:not(.theme-light) .chat-modal .composer button{
+      --composer-btn-bg:#ffffff;
+      --composer-btn-bg-hover:#f8fafc;
+      --composer-btn-bg-active:#e2e8f0;
+      --composer-btn-color:#0f172a;
+      box-shadow:0 12px 26px rgba(8,12,20,.28);
+    }
+    body.theme-light .chat-modal .composer{
+      background:#ffffff;
+      border-color:rgba(148,163,184,.5);
+      box-shadow:0 18px 40px rgba(15,23,42,.14);
+      color:#0f172a;
+    }
+    body.theme-light .chat-modal .composer:focus-within{
+      border-color:rgba(59,130,246,.45);
+      box-shadow:0 0 0 3px rgba(59,130,246,.25);
+      background:#ffffff;
+    }
     body.theme-light .chat-msg.user .bubble{border-color:var(--chat-border)}
     body.theme-light .chat-spinner{border-color:rgba(15,23,42,.18);border-top-color:var(--chat-accent)}
     body.theme-light .chat-msg.user .chat-spinner{border-color:rgba(15,23,42,.24);border-top-color:var(--chat-accent)}
-    body.theme-light .chat-modal .composer textarea::placeholder{color:rgba(15,23,42,.4)}
-    body.theme-light .chat-modal .composer textarea:focus{box-shadow:0 0 0 2px rgba(16,163,127,.25)}
+    body.theme-light .chat-modal .composer textarea::placeholder{color:rgba(15,23,42,.45)}
+    body.theme-light .chat-modal .composer button{
+      --composer-btn-bg:#111111;
+      --composer-btn-bg-hover:#000000;
+      --composer-btn-bg-active:#1f2937;
+      --composer-btn-color:#ffffff;
+      box-shadow:0 12px 28px rgba(15,23,42,.22);
+    }
     body.theme-light .chat-log{box-shadow:inset 0 1px 0 rgba(15,23,42,.06)}
     .chat-modal .chat-note{font-size:12px;line-height:1.5}
 
@@ -1010,7 +1049,10 @@
         <div id="chatLog" class="chat-log"></div>
         <div class="composer">
           <textarea id="chatInput" placeholder="Escribe un mensaje…"></textarea>
-          <button class="btn primary" id="btnSend">Enviar</button>
+          <button class="btn primary" id="btnSend">
+            <span class="sr-only">Enviar</span>
+            <span aria-hidden="true">↑</span>
+          </button>
         </div>
         <label class="small chat-share"><input type="checkbox" id="shareSecrets"> Compartir datos sensibles (PIN y notas)</label>
         <div class="small chat-note">Conexión directa a Gemini desde el navegador (API key expuesta).</div>


### PR DESCRIPTION
## Summary
- redesign the chat composer container as a single capsule with updated background, focus, and theme-aware styling
- make the composer textarea borderless and transparent while keeping flex growth and auto-resize behavior
- replace the send button text with an icon-only circular control with accessible labeling and hover/focus states

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d32134e838832eb0432468ff2f2085