### PR TITLE
Adjust chat composer padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -755,7 +755,7 @@
       display:flex;
       align-items:center;
       gap:0;
-      padding:10px 16px;
+      padding:6px 12px;
       border-radius:999px;
       border:1px solid rgba(236,236,241,.22);
       background:rgba(236,236,241,.08);
@@ -770,7 +770,8 @@
     }
     .chat-modal .composer textarea{
       flex:1;
-      padding:0;
+      padding-block:6px;
+      padding-inline-start:8px;
       margin:0;
       font-size:1rem;
       line-height:1.45;


### PR DESCRIPTION
## Summary
- reduce chat composer chip padding to slim its appearance while retaining pill shape
- add balanced padding within the composer textarea to center content and prevent clipping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d327be8068832e93942772a3f3b959