### PR TITLE
Increase chat composer textarea padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,12 +770,12 @@
     }
     .chat-modal .composer textarea{
       flex:1;
-      padding-block:6px;
+      padding-block:12px;
       padding-inline-start:8px;
       margin:0;
       font-size:1rem;
       line-height:1.45;
-      min-height:48px;
+      min-height:36px;
       max-height:220px;
       resize:none;
       overflow-y:hidden;


### PR DESCRIPTION
## Summary
- increase the textarea's vertical padding inside the chat composer for better vertical alignment
- reduce the textarea min-height to keep the composer height aligned with the adjacent send button

## Testing
- Manual verification of chat composer in light and dark modes

------
https://chatgpt.com/codex/tasks/task_e_68d32e881938832e8b8eef88126990fb