### PR TITLE
Create overlay panel for registered clients

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,11 @@ categoria:$('#categoria'), pin:$('#pin')};
 const q=$('#q'), filterEstado=$('#filterEstado'), msg=$('#msg');
 const sidebar=document.getElementById('sidebar');
 const sidebarLauncher=document.getElementById('sidebarLauncher');
+const panelClientes=document.getElementById('panelClientes');
+const panelClientesSheet=panelClientes?.querySelector('.panel-clientes__sheet')||null;
+const panelClientesOverlay=panelClientes?.querySelector('.panel-clientes__overlay')||null;
+const btnPanelClientesCerrar=document.getElementById('btnPanelClientesCerrar');
+const btnVerClientes=document.getElementById('btnVerClientes');
 
 const themeButton=document.getElementById('btnTheme');
 const themeLabel=document.getElementById('themeLabel');
@@ -560,6 +565,21 @@ async function renderTabla(){
     </tr>`;
   }).join('');
 }
+function abrirPanelClientes(){
+  if(!panelClientes) return;
+  panelClientes.classList.add('is-open');
+  panelClientes.setAttribute('aria-hidden','false');
+  requestAnimationFrame(()=>{
+    panelClientesSheet?.focus();
+  });
+}
+function cerrarPanelClientes(){
+  if(!panelClientes) return;
+  const wasOpen=panelClientes.classList.contains('is-open');
+  panelClientes.classList.remove('is-open');
+  panelClientes.setAttribute('aria-hidden','true');
+  if(wasOpen) btnVerClientes?.focus();
+}
 function coincide(x,qq){
   qq=(qq||'').trim().toLowerCase(); if(!qq) return true;
   return [x.nombre,x.email,x.servicio,x.telefono,x.categoria,x.notas].some(v=>(v||'').toLowerCase().includes(qq));
@@ -567,6 +587,12 @@ function coincide(x,qq){
 function pasaEstado(x,f){ if(!f) return true; return estadoDe(x.vence)===f; }
 
 $('#btnLimpiar').onclick=limpiar;
+btnVerClientes?.addEventListener('click',()=>{ renderTabla().then(()=>abrirPanelClientes()); });
+btnPanelClientesCerrar?.addEventListener('click',()=>cerrarPanelClientes());
+panelClientesOverlay?.addEventListener('click',()=>cerrarPanelClientes());
+document.addEventListener('keydown',e=>{
+  if(e.key==='Escape' && panelClientes?.classList.contains('is-open')) cerrarPanelClientes();
+});
 
 /* ===== EMAIL dropdown (principal) ===== */
 function rebuildEmailSuggestions(){
@@ -842,6 +868,7 @@ $('#btnGuardar').onclick = async ()=>{
   try{
     await db.saveOne(data); await renderTabla(); limpiar();
     toast(wasGuest && !currentUser ? 'Guardado local ✓  Accede para sincronizar' : 'Guardado ✓');
+    abrirPanelClientes();
   }catch(err){ toast(err?.message || 'No se pudo guardar.'); }
 };
 function editar(id){

--- a/index.html
+++ b/index.html
@@ -131,32 +131,42 @@
       <p>Guarda el nuevo cliente o limpia el formulario antes de continuar.</p>
       <div class="actions">
         <button class="btn primary" id="btnGuardar">Agregar</button>
+        <button class="btn ghost" id="btnVerClientes" type="button">Ver registrados</button>
         <button class="btn ghost" id="btnLimpiar">Limpiar</button>
       </div>
       <div class="small" id="msg"></div>
     </aside>
-
-    <!-- tabla -->
-    <section id="TablaClientes" class="table-section">
-      <div class="table-header">
-        <h2 id="clientesTitulo">Clientes registrados</h2>
-        <p>Consulta el listado completo y gestiona cada registro.</p>
-      </div>
-      <div class="table-card">
-        <div class="table-scroll" role="region" aria-labelledby="clientesTitulo" tabindex="0">
-          <table id="tabla">
-            <thead>
-              <tr>
-                <th>Nombre</th><th>Email</th><th>Servicio</th>
-                <th>Inicio</th><th>Vence</th><th>Estado</th><th>Días</th><th><span class="sr-only">Acciones</span></th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
-        </div>
-      </div>
-    </section>
   </main>
+
+  <aside id="panelClientes" class="panel-clientes" aria-hidden="true">
+    <div class="panel-clientes__overlay" data-panel-close></div>
+    <div class="panel-clientes__sheet" role="dialog" aria-modal="true" aria-labelledby="clientesTitulo" tabindex="-1">
+      <div class="panel-clientes__content">
+        <section id="TablaClientes" class="table-section">
+          <div class="table-header">
+            <div class="table-header-info">
+              <h2 id="clientesTitulo">Clientes registrados</h2>
+              <p>Consulta el listado completo y gestiona cada registro.</p>
+            </div>
+            <button class="btn ghost panel-clientes-close" id="btnPanelClientesCerrar" type="button">Cerrar</button>
+          </div>
+          <div class="table-card">
+            <div class="table-scroll" role="region" aria-labelledby="clientesTitulo" tabindex="0">
+              <table id="tabla">
+                <thead>
+                  <tr>
+                    <th>Nombre</th><th>Email</th><th>Servicio</th>
+                    <th>Inicio</th><th>Vence</th><th>Estado</th><th>Días</th><th><span class="sr-only">Acciones</span></th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </aside>
 
   <!-- ===== Modal Chat ChatGPT ===== -->
   <div id="chatModal" class="modal-backdrop" aria-hidden="true">

--- a/styles.css
+++ b/styles.css
@@ -155,7 +155,7 @@
     }
     *{box-sizing:border-box;font-family:Inter,ui-sans-serif,system-ui,Segoe UI,Roboto,Arial}
     html,body{margin:0;min-height:100%;background:var(--bg);color:var(--ink)}
-    body{position:relative;min-height:100vh;overflow-x:hidden;padding-left:0;transition:padding-left .3s ease;--hero-opacity:0}
+    body{position:relative;min-height:100vh;overflow:hidden;padding-left:0;transition:padding-left .3s ease;--hero-opacity:0}
     body.page-loaded{--hero-opacity:1}
     body::before{
       content:"";
@@ -420,12 +420,24 @@
     #Header,#BarraServicio,#AppGrid{width:min(1200px,92vw);margin:0 auto}
     #Header{padding:36px 18px 0;position:relative;z-index:0;opacity:var(--hero-opacity);transform:translateY(24px);filter:blur(8px);transition:opacity .55s ease,transform .55s ease,filter .55s ease}
     #BarraServicio{padding:0 18px}
-    #AppGrid{padding:0 18px 80px;margin-top:32px;display:grid;grid-template-columns:minmax(0,1fr);grid-template-areas:"form" "acciones" "tabla";gap:24px}
+    #AppGrid{padding:0 18px;margin-top:32px;min-height:100vh;display:grid;grid-template-columns:minmax(0,1fr);grid-template-areas:"form" "acciones";gap:24px}
     #Formulario{grid-area:form}
     #AccionesRapidas{grid-area:acciones}
-    #TablaClientes{grid-area:tabla;margin-top:0}
+    #TablaClientes{margin-top:0;display:none}
     @media(min-width:960px){
-      #AppGrid{grid-template-columns:minmax(0,2fr)minmax(0,1fr);grid-template-areas:"form acciones" "tabla tabla";}
+      #AppGrid{grid-template-columns:minmax(0,2fr)minmax(0,1fr);grid-template-areas:"form acciones";}
+    }
+    .panel-clientes{position:fixed;inset:0;display:flex;justify-content:flex-end;align-items:stretch;opacity:0;visibility:hidden;pointer-events:none;transition:opacity .25s ease;z-index:90}
+    .panel-clientes__overlay{position:absolute;inset:0;background:var(--backdrop-bg);opacity:0;transition:opacity .25s ease}
+    .panel-clientes__sheet{position:relative;z-index:1;width:min(640px,96vw);max-width:680px;height:100%;background:var(--panel-bg);border-left:1px solid var(--panel-border);box-shadow:var(--panel-shadow);transform:translateX(24px);transition:transform .28s ease,opacity .28s ease;display:flex;flex-direction:column;opacity:0;overflow:hidden;border-radius:24px 0 0 24px}
+    .panel-clientes__sheet:focus{outline:2px solid rgba(125,211,252,.45);outline-offset:-4px}
+    .panel-clientes__content{flex:1;overflow:auto;padding:32px 28px 28px;display:flex;flex-direction:column;gap:24px}
+    .panel-clientes.is-open{opacity:1;visibility:visible;pointer-events:auto}
+    .panel-clientes.is-open .panel-clientes__overlay{opacity:1}
+    .panel-clientes.is-open .panel-clientes__sheet{transform:translateX(0);opacity:1}
+    .panel-clientes.is-open #TablaClientes{display:flex}
+    @media(max-width:720px){
+      .panel-clientes__sheet{width:100%;max-width:none;border-radius:0}
     }
     .pill{display:block;width:max-content;margin:0 auto 14px;padding:6px 14px;border-radius:999px;background:var(--pill-bg);color:var(--pill-ink);border:1px solid var(--border);font-size:12px;letter-spacing:.08em;text-transform:uppercase}
     #Header .pill{opacity:var(--hero-opacity);transform:translateY(18px);filter:blur(6px);transition:opacity .5s ease,transform .5s ease,filter .5s ease;transition-delay:.05s}
@@ -571,12 +583,18 @@
 
     /* ===== Tabla ===== */
     .table-section{margin-top:40px;display:flex;flex-direction:column;gap:18px}
-    .table-header{display:flex;flex-direction:column;gap:6px}
+    .table-header{display:flex;flex-direction:column;gap:12px}
+    .table-header-info{display:flex;flex-direction:column;gap:6px}
     @media(min-width:720px){
       .table-header{flex-direction:row;align-items:flex-end;justify-content:space-between}
     }
     .table-header h2{margin:0;font-size:22px;font-weight:700;color:var(--ink);text-shadow:0 10px 20px rgba(0,0,0,.35)}
     .table-header p{margin:0;color:var(--muted);font-size:14px}
+    .panel-clientes .panel-clientes__content{padding:32px 28px 32px}
+    .panel-clientes .table-section{margin-top:0;flex:1}
+    .panel-clientes .table-card{flex:1;display:flex;flex-direction:column}
+    .panel-clientes .table-scroll{flex:1}
+    .panel-clientes .panel-clientes-close{align-self:flex-start}
     .table-card{
       position:relative;
       background:var(--table-card-bg);


### PR DESCRIPTION
## Summary
- wrap the registered clients table in a modal-style panel and add controls to open or close it
- adjust layout styles to give AppGrid full height and hide the table until the panel is visible
- update the save handler to open the panel after persisting data and expose a manual "Ver registrados" action

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8b988228c832e9862faa9f7676fea